### PR TITLE
Add gait datasets and download script for Parkinson's disease research

### DIFF
--- a/datasets/.gitignore
+++ b/datasets/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all downloaded dataset content by default
+*
+!.gitignore
+!README.md

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,54 @@
+# Datasets: gaitpdb and gaitndd
+
+This folder holds external gait datasets that are downloaded on demand and kept out of version control to avoid committing large binaries. Use the provided script to fetch and extract the data locally.
+
+Contents after download:
+- datasets/gaitpdb/ … PhysioNet “Gait in Parkinson’s Disease” (gaitpdb)
+- datasets/gaitndd/ … PhysioNet “Gait in Neurodegenerative Disease” (gaitndd)
+
+How to download
+- Prerequisite: R (base R is sufficient; no extra packages required).
+- From the project root, run:
+
+  Rscript scripts/download_gait_datasets.R
+
+- By default, the script skips datasets that already exist. To force a re-download:
+
+  Rscript scripts/download_gait_datasets.R --force
+
+What you will get
+
+1) Gait in Parkinson’s Disease (gaitpdb)
+- Source: PhysioNet (Jeffrey Hausdorff et al.)
+- Data: Vertical ground reaction force records from instrumented shoes with 8 sensors per foot (16 channels total), plus per-foot summed force signals.
+- Cohort: 93 idiopathic PD patients and 73 healthy controls; some trials include a dual-task condition.
+- Sampling: 100 Hz; ~2 minutes per recording.
+- Path after extraction: datasets/gaitpdb/gaitpdb-1.0.0/ (multiple .txt files and metadata)
+- Home page: https://physionet.org/content/gaitpdb/1.0.0/
+- License: Open Data Commons Attribution (ODC-By 1.0)
+  https://physionet.org/content/gaitpdb/view-license/1.0.0/
+- Citation: Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, et al. PhysioBank, PhysioToolkit, and PhysioNet. Circulation. 2000.
+
+2) Gait in Neurodegenerative Disease (gaitndd)
+- Source: PhysioNet (Jeffrey Hausdorff)
+- Data: Force-sensitive resistors (footswitch) signals under each foot (left/right) and derived time series of stride, swing, stance, and double support intervals.
+- Cohort: PD (n=15), Huntington’s (n=20), ALS (n=13), and healthy controls (n=16).
+- Path after extraction: datasets/gaitndd/gaitndd-1.0.0/ (binary .let/.rit foot signals, .ts time series, headers)
+- Home page: https://physionet.org/content/gaitndd/1.0.0/
+- License: Open Data Commons Attribution (ODC-By 1.0)
+  https://physionet.org/content/gaitndd/view-license/1.0.0/
+- Citation: Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, et al. PhysioBank, PhysioToolkit, and PhysioNet. Circulation. 2000.
+
+Notes on licensing and use
+- Both datasets are licensed under ODC-By 1.0 on PhysioNet and permit academic use with attribution. Review the license pages above before use and include appropriate citations in your reports/publications.
+
+Disk space and network
+- gaitpdb ZIP is approximately 288 MB; extracted size is larger.
+- gaitndd ZIP is approximately 18 MB.
+- Downloads may take several minutes depending on network speed.
+
+Checksums
+- The download script also fetches the upstream SHA256SUMS.txt into each dataset subfolder for reference. If you need formal verification, compute checksums locally and compare to the provided list.
+
+Keep data out of version control
+- This folder contains a .gitignore that intentionally ignores downloaded dataset content. Do not commit large datasets into the repository.

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,22 @@ This brief overview explains how the repo is prepared to use R with Cosine.sh: a
 
 Transcript: [Setup Initial R Repository – full transcript](transcripts/r-repository-setup.md)
 
+## Parkinson’s Gait Datasets (gaitpdb & gaitndd)
+
+This tutorial covers two PhysioNet datasets widely used for Parkinson’s gait research—gaitpdb (in‑shoe force sensors; PD + controls) and gaitndd (footswitch signals; PD, Huntington’s, ALS, controls). It explains what data are included, access/licensing, how to download them into this repo, and how to generate quick characterizations (duration, stride means/variability, swing/stance/double support) using the provided R scripts.
+
+- Transcript: [Parkinson’s Gait Datasets – full transcript](transcripts/pd-gait-datasets.md)
+- Scripts:
+  - Download both datasets: [scripts/download_gait_datasets.R](scripts/download_gait_datasets.R)
+  - Characterize gaitpdb: [scripts/characterize_gaitpdb.R](scripts/characterize_gaitpdb.R)
+  - Characterize gaitndd: [scripts/characterize_gaitndd.R](scripts/characterize_gaitndd.R)
+- Dataset folder notes: [datasets/README.md](datasets/README.md)
+
+Quick commands:
+- Rscript scripts/download_gait_datasets.R
+- Rscript scripts/characterize_gaitpdb.R
+- Rscript scripts/characterize_gaitndd.R
+
 ---
 
 Project now includes:

--- a/scripts/characterize_gaitndd.R
+++ b/scripts/characterize_gaitndd.R
@@ -1,0 +1,182 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(tidyverse)
+})
+
+# Characterize PhysioNet "Gait in Neurodegenerative Disease" (gaitndd)
+# - Summarizes per-record duration and stride/swing/stance/double-support statistics from .ts files.
+# - Outputs CSV summaries and overview plots into outputs/gaitndd/.
+#
+# Assumptions:
+# - Data were downloaded via scripts/download_gait_datasets.R
+# - Files are under datasets/gaitndd/gaitndd-1.0.0/
+#
+# References:
+# - https://physionet.org/content/gaitndd/1.0.0/
+# - .ts columns (tab-separated):
+#   1) time (s), 2) L stride, 3) R stride, 4) L swing (s), 5) R swing (s),
+#   6) L swing (%), 7) R swing (%), 8) L stance (s), 9) R stance (s),
+#   10) L stance (%), 11) R stance (%), 12) double support (s), 13) double support (%)
+
+dataset_base <- file.path("datasets", "gaitndd")
+
+resolve_dataset_dir <- function(base_dir) {
+  if (!dir.exists(base_dir)) return(NA_character_)
+  subdirs <- list.dirs(base_dir, recursive = FALSE, full.names = TRUE)
+  cand <- subdirs[grepl("gaitndd", basename(subdirs), ignore.case = TRUE)]
+  if (length(cand) > 0) return(cand[[1]])
+  return(base_dir)
+}
+
+ds_dir <- resolve_dataset_dir(dataset_base)
+if (is.na(ds_dir) || !dir.exists(ds_dir)) {
+  stop("Dataset folder not found. Run: Rscript scripts/download_gait_datasets.R")
+}
+
+# Output folders
+out_dir <- file.path("outputs", "gaitndd")
+plot_dir <- file.path(out_dir, "plots")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+dir.create(plot_dir, recursive = TRUE, showWarnings = FALSE)
+
+# .ts files list
+ts_files <- list.files(ds_dir, pattern = "\\.ts$", full.names = TRUE)
+if (length(ts_files) == 0) {
+  stop("No .ts files found in gaitndd. Check that data were extracted into datasets/gaitndd/ ...")
+}
+
+# Subject description (optional, for reference)
+subj_desc_path <- file.path(ds_dir, "subject-description.txt")
+subj_desc <- NULL
+if (file.exists(subj_desc_path)) {
+  subj_desc <- tryCatch(
+    readr::read_tsv(subj_desc_path, col_names = FALSE, show_col_types = FALSE),
+    error = function(e) NULL
+  )
+  if (!is.null(subj_desc) && ncol(subj_desc) >= 1) {
+    names(subj_desc)[1] <- "record"
+  }
+}
+
+# Helper: get record id and group from filename
+parse_record_id <- function(path) {
+  b <- tools::file_path_sans_ext(basename(path))
+  group <- sub("[0-9]+$", "", b)  # prefix: park, hunt, als, control
+  tibble(
+    file = path,
+    record = b,
+    group = dplyr::case_when(
+      group == "park" ~ "pd",
+      group == "control" ~ "control",
+      group == "hunt" ~ "huntington",
+      group == "als" ~ "als",
+      TRUE ~ group
+    )
+  )
+}
+
+# Summarize one .ts file
+summarize_ts <- function(f) {
+  dat <- suppressWarnings(readr::read_tsv(
+    f, col_names = FALSE, show_col_types = FALSE, progress = FALSE
+  ))
+  if (ncol(dat) < 13) return(NULL)
+  names(dat) <- c(
+    "time_s", "l_stride_s", "r_stride_s", "l_swing_s", "r_swing_s",
+    "l_swing_pct", "r_swing_pct", "l_stance_s", "r_stance_s",
+    "l_stance_pct", "r_stance_pct", "ds_s", "ds_pct"
+  )
+  # Duration = last time stamp
+  duration_s <- if (nrow(dat) > 0) max(dat$time_s, na.rm = TRUE) else NA_real_
+
+  # Helper to make stats safely
+  smean <- function(x) if (all(is.na(x))) NA_real_ else mean(x, na.rm = TRUE)
+  ssd   <- function(x) if (all(is.na(x))) NA_real_ else sd(x, na.rm = TRUE)
+  scv   <- function(x) {
+    m <- smean(x); s <- ssd(x)
+    if (is.na(m) || m <= 0) NA_real_ else 100 * s / m
+  }
+
+  tibble(
+    file = f,
+    duration_s = duration_s,
+    n_rows = nrow(dat),
+    l_stride_mean_s = smean(dat$l_stride_s),
+    l_stride_sd_s = ssd(dat$l_stride_s),
+    l_stride_cv_pct = scv(dat$l_stride_s),
+    r_stride_mean_s = smean(dat$r_stride_s),
+    r_stride_sd_s = ssd(dat$r_stride_s),
+    r_stride_cv_pct = scv(dat$r_stride_s),
+    l_swing_mean_s = smean(dat$l_swing_s),
+    r_swing_mean_s = smean(dat$r_swing_s),
+    l_swing_mean_pct = smean(dat$l_swing_pct),
+    r_swing_mean_pct = smean(dat$r_swing_pct),
+    l_stance_mean_s = smean(dat$l_stance_s),
+    r_stance_mean_s = smean(dat$r_stance_s),
+    l_stance_mean_pct = smean(dat$l_stance_pct),
+    r_stance_mean_pct = smean(dat$r_stance_pct),
+    ds_mean_s = smean(dat$ds_s),
+    ds_mean_pct = smean(dat$ds_pct)
+  )
+}
+
+message("Scanning gaitndd .ts files ...")
+ids <- map_dfr(ts_files, parse_record_id)
+summ <- map_dfr(ts_files, summarize_ts)
+
+summary_records <- ids %>%
+  left_join(summ, by = "file") %>%
+  relocate(group, record, .after = file) %>%
+  mutate(dataset = "gaitndd")
+
+# Write per-record summary
+out_csv <- file.path(out_dir, "characterization_records.csv")
+readr::write_csv(summary_records, out_csv)
+message("Wrote: ", out_csv)
+
+# Overview by group
+overview <- summary_records %>%
+  group_by(group) %>%
+  summarise(
+    n_records = n(),
+    mean_duration_s = mean(duration_s, na.rm = TRUE),
+    median_l_stride_s = median(l_stride_mean_s, na.rm = TRUE),
+    median_r_stride_s = median(r_stride_mean_s, na.rm = TRUE),
+    median_l_cv_pct = median(l_stride_cv_pct, na.rm = TRUE),
+    median_r_cv_pct = median(r_stride_cv_pct, na.rm = TRUE),
+    median_ds_pct = median(ds_mean_pct, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+out_overview <- file.path(out_dir, "characterization_overview.csv")
+readr::write_csv(overview, out_overview)
+message("Wrote: ", out_overview)
+
+# Plots
+p1 <- summary_records %>%
+  filter(group %in% c("pd", "control")) %>%
+  ggplot(aes(x = l_stride_mean_s, fill = group)) +
+  geom_histogram(alpha = 0.6, position = "identity", bins = 30) +
+  labs(
+    title = "gaitndd: Left stride mean (s) by group",
+    x = "Left stride mean (s)", y = "Count"
+  ) +
+  theme_minimal()
+
+p2 <- summary_records %>%
+  filter(group %in% c("pd", "control")) %>%
+  ggplot(aes(x = r_stride_mean_s, fill = group)) +
+  geom_histogram(alpha = 0.6, position = "identity", bins = 30) +
+  labs(
+    title = "gaitndd: Right stride mean (s) by group",
+    x = "Right stride mean (s)", y = "Count"
+  ) +
+  theme_minimal()
+
+ggplot2::ggsave(file.path(plot_dir, "left_stride_mean_hist.png"), p1, width = 7, height = 5, dpi = 150)
+ggplot2::ggsave(file.path(plot_dir, "right_stride_mean_hist.png"), p2, width = 7, height = 5, dpi = 150)
+
+message("Saved plots to: ", plot_dir)
+print(overview)
+message("Characterization complete for gaitndd.")

--- a/scripts/characterize_gaitpdb.R
+++ b/scripts/characterize_gaitpdb.R
@@ -1,0 +1,224 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(tidyverse)
+})
+
+# Characterize PhysioNet "Gait in Parkinson's Disease" (gaitpdb)
+# - Summarizes per-trial duration and stride statistics derived from per-foot total force.
+# - Outputs CSV summaries and a few overview plots into outputs/gaitpdb/.
+#
+# Assumptions:
+# - Data were downloaded via scripts/download_gait_datasets.R
+# - Files are under datasets/gaitpdb/gaitpdb-1.0.0/
+# - Sampling rate = 100 Hz
+#
+# References:
+# - https://physionet.org/content/gaitpdb/1.0.0/
+# - format.txt describes the 19-column layout
+#
+# Columns per row (tab-separated):
+# 1: time (s)
+# 2–9: left foot sensors (N), 10–17: right foot sensors (N)
+# 18: total left force (N), 19: total right force (N)
+
+dataset_base <- file.path("datasets", "gaitpdb")
+sampling_rate <- 100
+
+# Resolve extracted directory (gaitpdb-1.0.0) if present
+resolve_dataset_dir <- function(base_dir) {
+  if (!dir.exists(base_dir)) return(NA_character_)
+  subdirs <- list.dirs(base_dir, recursive = FALSE, full.names = TRUE)
+  cand <- subdirs[grepl("gaitpdb", basename(subdirs), ignore.case = TRUE)]
+  if (length(cand) > 0) return(cand[[1]])
+  return(base_dir)
+}
+
+ds_dir <- resolve_dataset_dir(dataset_base)
+if (is.na(ds_dir) || !dir.exists(ds_dir)) {
+  stop("Dataset folder not found. Run: Rscript scripts/download_gait_datasets.R")
+}
+
+# Output folders
+out_dir <- file.path("outputs", "gaitpdb")
+plot_dir <- file.path(out_dir, "plots")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+dir.create(plot_dir, recursive = TRUE, showWarnings = FALSE)
+
+# Identify data files (exclude non-trial text files)
+all_txt <- list.files(ds_dir, pattern = "\\.txt$", full.names = TRUE)
+trial_files <- all_txt[grepl("_[0-9]+\\.txt$", basename(all_txt)) &
+                         !grepl("SHA256|demo|format|readme|README", basename(all_txt), ignore.case = TRUE)]
+
+if (length(trial_files) == 0) {
+  stop("No gaitpdb trial files found. Check that data were extracted into datasets/gaitpdb/ ...")
+}
+
+# Helper: parse group/subject/trial from filename
+parse_id <- function(fname) {
+  b <- tools::file_path_sans_ext(basename(fname))
+  tibble(
+    file = fname,
+    base = b,
+    group = case_when(
+      grepl("Co", b) ~ "control",
+      grepl("Pt", b) ~ "pd",
+      TRUE ~ "unknown"
+    ),
+    study = substr(b, 1, 2),
+    subj_num = {
+      m <- regmatches(b, regexpr("(Co|Pt)([0-9]+)", b))
+      sub("^.*(Co|Pt)([0-9]+).*$", "\\2", m)
+    },
+    walk_id = {
+      m <- regmatches(b, regexpr("_(\\d+)$", b))
+      sub("^_+", "", sub("^.*_(\\d+)$", "\\1", m))
+    }
+  )
+}
+
+# Helper: detect heel-strike and toe-off from total force using threshold + hysteresis
+detect_events <- function(time, total_force, thrN = NULL) {
+  # dynamic threshold if not supplied
+  if (is.null(thrN)) {
+    # Use max(50 N, 5% of max force)
+    thrN <- max(50, 0.05 * max(total_force, na.rm = TRUE))
+  }
+  st <- total_force > thrN
+  d <- diff(as.integer(st))
+  hs_idx <- which(d == 1L) + 1L  # rising edge: heel strike
+  to_idx <- which(d == -1L) + 1L # falling edge: toe off
+  list(
+    hs_time = time[hs_idx],
+    to_time = time[to_idx],
+    hs_idx = hs_idx,
+    to_idx = to_idx,
+    thr = thrN
+  )
+}
+
+# Helper: stride times from successive heel strikes
+stride_stats <- function(hs_time) {
+  if (length(hs_time) < 2) {
+    return(tibble(
+      n_strides = 0L,
+      stride_mean = NA_real_,
+      stride_sd = NA_real_,
+      stride_cv = NA_real_
+    ))
+  }
+  st <- diff(hs_time)
+  tibble(
+    n_strides = length(st),
+    stride_mean = mean(st, na.rm = TRUE),
+    stride_sd = sd(st, na.rm = TRUE),
+    stride_cv = ifelse(mean(st, na.rm = TRUE) > 0, 100 * sd(st, na.rm = TRUE) / mean(st, na.rm = TRUE), NA_real_)
+  )
+}
+
+# Read one trial, compute summary
+summarize_trial <- function(f) {
+  dat <- suppressWarnings(readr::read_tsv(
+    f, col_names = FALSE, progress = FALSE, show_col_types = FALSE
+  ))
+  # Expect at least 19 columns
+  if (ncol(dat) < 19) {
+    return(NULL)
+  }
+  time <- dat[[1]]
+  # Prefer provided totals in cols 18/19; fallback to sums
+  left_total  <- if (ncol(dat) >= 18) dat[[18]] else rowSums(dat[, 2:9, drop = FALSE])
+  right_total <- if (ncol(dat) >= 19) dat[[19]] else rowSums(dat[, 10:17, drop = FALSE])
+
+  # Events
+  le <- detect_events(time, left_total)
+  re <- detect_events(time, right_total)
+
+  # Stride stats
+  lss <- stride_stats(le$hs_time)
+  rss <- stride_stats(re$hs_time)
+
+  duration_s <- if (!is.null(time) && length(time) > 1) {
+    max(time, na.rm = TRUE) - min(time, na.rm = TRUE)
+  } else {
+    length(time) / sampling_rate
+  }
+
+  tibble(
+    file = f,
+    duration_s = duration_s,
+    left_thr_N = le$thr,
+    right_thr_N = re$thr,
+    left_n_strides = lss$n_strides,
+    left_stride_mean_s = lss$stride_mean,
+    left_stride_sd_s = lss$stride_sd,
+    left_stride_cv_pct = lss$stride_cv,
+    right_n_strides = rss$n_strides,
+    right_stride_mean_s = rss$stride_mean,
+    right_stride_sd_s = rss$stride_sd,
+    right_stride_cv_pct = rss$stride_cv
+  )
+}
+
+message("Scanning gaitpdb trial files ...")
+ids <- map_dfr(trial_files, parse_id)
+summ <- map_dfr(trial_files, summarize_trial)
+
+# Merge IDs with summaries
+summary_trials <- ids %>%
+  select(file, base, study, group, subj_num, walk_id) %>%
+  left_join(summ, by = "file") %>%
+  relocate(study, group, subj_num, walk_id, .after = base)
+
+# Write per-trial summary
+out_csv <- file.path(out_dir, "characterization_trials.csv")
+readr::write_csv(summary_trials, out_csv)
+message("Wrote: ", out_csv)
+
+# Aggregate overview by group
+overview <- summary_trials %>%
+  mutate(dataset = "gaitpdb") %>%
+  group_by(group) %>%
+  summarise(
+    n_trials = n(),
+    mean_duration_s = mean(duration_s, na.rm = TRUE),
+    median_left_stride_s = median(left_stride_mean_s, na.rm = TRUE),
+    median_right_stride_s = median(right_stride_mean_s, na.rm = TRUE),
+    median_left_cv_pct = median(left_stride_cv_pct, na.rm = TRUE),
+    median_right_cv_pct = median(right_stride_cv_pct, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+out_overview <- file.path(out_dir, "characterization_overview.csv")
+readr::write_csv(overview, out_overview)
+message("Wrote: ", out_overview)
+
+# Plots: distribution of stride mean by group
+p1 <- summary_trials %>%
+  filter(!is.na(left_stride_mean_s), group %in% c("pd", "control")) %>%
+  ggplot(aes(x = left_stride_mean_s, fill = group)) +
+  geom_histogram(alpha = 0.6, position = "identity", bins = 30) +
+  labs(
+    title = "gaitpdb: Left stride mean (s) by group",
+    x = "Left stride mean (s)", y = "Count"
+  ) +
+  theme_minimal()
+
+p2 <- summary_trials %>%
+  filter(!is.na(right_stride_mean_s), group %in% c("pd", "control")) %>%
+  ggplot(aes(x = right_stride_mean_s, fill = group)) +
+  geom_histogram(alpha = 0.6, position = "identity", bins = 30) +
+  labs(
+    title = "gaitpdb: Right stride mean (s) by group",
+    x = "Right stride mean (s)", y = "Count"
+  ) +
+  theme_minimal()
+
+ggplot2::ggsave(file.path(plot_dir, "left_stride_mean_hist.png"), p1, width = 7, height = 5, dpi = 150)
+ggplot2::ggsave(file.path(plot_dir, "right_stride_mean_hist.png"), p2, width = 7, height = 5, dpi = 150)
+
+message("Saved plots to: ", plot_dir)
+
+# Done
+print(overview)
+message("Characterization complete for gaitpdb.")

--- a/scripts/download_gait_datasets.R
+++ b/scripts/download_gait_datasets.R
@@ -1,0 +1,85 @@
+#!/usr/bin/env Rscript
+
+# Download and extract PD gait datasets into datasets/
+# - gaitpdb: PhysioNet "Gait in Parkinson's Disease"
+# - gaitndd: PhysioNet "Gait in Neurodegenerative Disease"
+#
+# Usage:
+#   Rscript scripts/download_gait_datasets.R
+#   Rscript scripts/download_gait_datasets.R --force   # re-download and re-extract
+#
+# Notes:
+# - Requires only base R (utils). No extra packages needed.
+# - Extracted folders will be created under datasets/{gaitpdb,gaitndd}
+# - Large files are intentionally kept out of git via datasets/.gitignore
+
+args <- commandArgs(trailingOnly = TRUE)
+force_redownload <- any(args %in% c("--force", "-f"))
+
+# Increase timeout for large downloads
+options(timeout = max(600, getOption("timeout", 60)))
+
+datasets <- list(
+  list(
+    name    = "gaitpdb",
+    zip_url = "https://physionet.org/content/gaitpdb/get-zip/1.0.0/",
+    sha_url = "https://physionet.org/content/gaitpdb/1.0.0/SHA256SUMS.txt",
+    info    = "PhysioNet: Gait in Parkinson's Disease (vertical GRF via in-shoe sensors)"
+  ),
+  list(
+    name    = "gaitndd",
+    zip_url = "https://physionet.org/content/gaitndd/get-zip/1.0.0/",
+    sha_url = "https://physionet.org/content/gaitndd/1.0.0/SHA256SUMS.txt",
+    info    = "PhysioNet: Gait in Neurodegenerative Disease (footswitch signals + derived time series)"
+  )
+)
+
+root <- getwd()
+base_dir <- file.path(root, "datasets")
+if (!dir.exists(base_dir)) dir.create(base_dir, recursive = TRUE, showWarnings = FALSE)
+
+download_into <- function(d) {
+  sub_dir <- file.path(base_dir, d$name)
+  if (!dir.exists(sub_dir)) dir.create(sub_dir, recursive = TRUE, showWarnings = FALSE)
+
+  existing_files <- list.files(sub_dir, recursive = TRUE, all.files = TRUE, no.. = TRUE)
+  if (!force_redownload && length(existing_files) > 0) {
+    message(sprintf("Skipping %s: found existing files in %s. Use --force to re-download.",
+                    d$name, sub_dir))
+    return(invisible(TRUE))
+  }
+
+  # If forcing, clear the subdirectory first
+  if (force_redownload && length(existing_files) > 0) {
+    message(sprintf("Removing existing contents in %s ...", sub_dir))
+    unlink(list.files(sub_dir, full.names = TRUE, recursive = TRUE), recursive = TRUE, force = TRUE)
+  }
+
+  message(sprintf("\n[%s] %s", d$name, d$info))
+  message(sprintf("[%s] Downloading ZIP from: %s", d$name, d$zip_url))
+
+  zip_tmp <- tempfile(pattern = paste0(d$name, "_"), fileext = ".zip")
+  utils::download.file(d$zip_url, destfile = zip_tmp, mode = "wb", quiet = FALSE)
+
+  message(sprintf("[%s] Extracting into: %s", d$name, sub_dir))
+  utils::unzip(zip_tmp, exdir = sub_dir)
+  unlink(zip_tmp)
+
+  # Try to fetch the upstream SHA256 list for reference
+  if (!is.null(d$sha_url) && nzchar(d$sha_url)) {
+    sha_dest <- file.path(sub_dir, "SHA256SUMS.txt")
+    message(sprintf("[%s] Downloading upstream checksums: %s", d$name, d$sha_url))
+    try(utils::download.file(d$sha_url, destfile = sha_dest, mode = "wb", quiet = TRUE), silent = TRUE)
+  }
+
+  n_files <- length(list.files(sub_dir, recursive = TRUE, all.files = TRUE, no.. = TRUE))
+  message(sprintf("[%s] Done. Extracted %d files.", d$name, n_files))
+  invisible(TRUE)
+}
+
+status <- vapply(datasets, download_into, logical(1))
+if (all(status)) {
+  message("\nAll requested datasets are ready under datasets/.")
+} else {
+  message("\nSome datasets failed to download or extract. See messages above.")
+}

--- a/transcripts/pd-gait-datasets.md
+++ b/transcripts/pd-gait-datasets.md
@@ -1,0 +1,139 @@
+# Conversation Transcript: Parkinson’s Gait Datasets (gaitpdb & gaitndd) – discovery, integration, and characterization
+
+Generated: 2025-09-21
+Participants: User and Genie (Cosine AI)
+
+Note on reasoning privacy:
+- This transcript includes the full user-assistant message exchange and a concise, high-level summary of the assistant’s reasoning and actions taken.
+- It intentionally excludes hidden chain-of-thought or internal deliberations. Instead, a brief worklog summarizes decisions and steps.
+
+---
+
+## Conversation Log
+
+### 1) User
+Task summaries so far: Here are five datasets containing footfall-related data suitable for Parkinson’s gait analysis, including descriptions, data features, and licensing/access notes relevant for academic use:
+
+1. PhysioNet — Gait in Parkinson’s Disease (gaitpdb) … [full dataset overview, links, license ODC‑By]
+2. PhysioNet — Gait in Neurodegenerative Disease (gaitndd) … [signals and .ts overview, ODC‑By]
+3. PhysioNet — Gait in Aging and Disease (gaitdb) … [stride-interval series, ODC‑By]
+4. Wearable Gait Dataset — WearGait-PD (FDA / Synapse) … [insoles + walkway + IMUs, CC BY]
+5. Figshare — Overground Full-Body Gait Kinematics and Kinetics in PD … [force plates + mocap, CC BY]
+
+Confirmed access to sample data from both gaitpdb and gaitndd datasets. Provided format details and example rows for gaitpdb (19 columns, 100 Hz) and gaitndd (.let/.rit/.ts structure, 13 fields in .ts), plus metadata notes.
+
+### 2) User
+Can you give me detailed information on the search procedure and criteria you used to find these datasets? Describe your thought process for choosing and researching each suggestion. I may need to include this in my report so I need detailed research notes.
+
+### 3) Assistant
+Provided an audit-ready, reproducible search and selection record:
+- Goal, dates, inclusion/exclusion criteria (PD cohort; footfall-capable sensors: FSR/insoles/GRF/walkway; open academic licensing), sources consulted (PhysioNet, FDA RST + Synapse, Figshare, PubMed/PMC), and staged search queries.
+- Verification for each candidate: footfall presence, PD cohort size, access path, license text, sensor/sampling details.
+- Rationale per selected dataset (gaitpdb, gaitndd, gaitdb, WearGait‑PD, Figshare), with direct links, license types, and caveats.
+- “Considered but excluded” list (e.g., Daphnet accelerometer-only, closed/unclear GAITRite datasets).
+- Replication checklist for future extensions.
+
+### 4) User
+Can you add gaitpdb and gaitndd to a dataset folder in my repository?
+
+### 5) Assistant
+Implemented:
+- datasets/README.md documenting gaitpdb and gaitndd, licensing, sizes, and download instructions.
+- scripts/download_gait_datasets.R to fetch and extract both datasets; stores upstream SHA256SUMS.txt; supports --force.
+- datasets/.gitignore to keep large data out of version control.
+
+Run:
+- Rscript scripts/download_gait_datasets.R
+
+### 6) User
+Does the data overview imply I can combine fields of these two datasets into a single dataset for analysis or would I have to review each one separately?
+
+### 7) Assistant
+Advised not to merge raw columns due to different modalities (gaitpdb VGRF vs gaitndd footswitch) and processing states. Recommended harmonizing to a shared set of derived stride-level temporal features (stride, swing, stance, double support, asymmetry), ideally using a unified HS/TO detection method across datasets, and modeling with a dataset indicator.
+
+### 8) User
+Write me an R script for each dataset that characterizes each dataset.
+
+### 9) Assistant
+Added:
+- scripts/characterize_gaitpdb.R
+  - Reads gaitpdb trial files; detects heel-strike/toe-off from total force via dynamic threshold; computes per-trial stride counts and mean/sd/CV (L/R); writes CSVs and histograms.
+- scripts/characterize_gaitndd.R
+  - Reads .ts files; summarizes duration and mean/sd/CV of stride plus swing/stance/double support; writes CSVs and histograms.
+
+Run:
+- Rscript scripts/characterize_gaitpdb.R
+- Rscript scripts/characterize_gaitndd.R
+
+### 10) User
+Update the README and create a transcript from our conversation. Be sure to include links to the scripts in the README.
+
+### 11) Assistant
+Updated readme.md to add the “Parkinson’s Gait Datasets (gaitpdb & gaitndd)” tutorial with:
+- Transcript link to this document.
+- Script links (download + characterization).
+- Quick commands and dataset folder notes.
+Created this transcript at transcripts/pd-gait-datasets.md.
+
+---
+
+## Assistant Worklog (Concise, high-level)
+
+- Discovery and vetting:
+  - Applied inclusion criteria (PD cohort, footfall-capable sensors, open licensing).
+  - Queried PhysioNet, FDA RST/Synapse, Figshare, and PubMed; verified footfall modality, sampling, and licensing on each landing page.
+- Integration:
+  - Added datasets/README.md and datasets/.gitignore to manage large data locally without committing.
+  - Wrote scripts/download_gait_datasets.R to retrieve and extract gaitpdb and gaitndd; stored upstream SHA256SUMS.txt.
+- Characterization:
+  - Implemented scripts/characterize_gaitpdb.R (HS/TO from total force; stride stats).
+  - Implemented scripts/characterize_gaitndd.R (derived .ts summaries; stride/swing/stance/double support).
+  - Selected clear outputs under outputs/gaitpdb/ and outputs/gaitndd/ including CSVs and quick-look plots.
+- Documentation:
+  - Updated README with a new tutorial section, direct links to scripts, and quick commands.
+  - Authored this transcript summarizing the conversation and actions.
+
+---
+
+## Files Added or Updated
+
+- datasets/README.md
+- datasets/.gitignore
+- scripts/download_gait_datasets.R
+- scripts/characterize_gaitpdb.R
+- scripts/characterize_gaitndd.R
+- readme.md (new tutorial section with links)
+- transcripts/pd-gait-datasets.md (this document)
+
+---
+
+## How to Reproduce
+
+1) Download datasets:
+- Rscript scripts/download_gait_datasets.R
+
+2) Characterize gaitpdb:
+- Rscript scripts/characterize_gaitpdb.R
+- Outputs: outputs/gaitpdb/characterization_trials.csv, overview CSV, and histograms.
+
+3) Characterize gaitndd:
+- Rscript scripts/characterize_gaitndd.R
+- Outputs: outputs/gaitndd/characterization_records.csv, overview CSV, and histograms.
+
+---
+
+## Links Referenced
+
+- PhysioNet gaitpdb: https://physionet.org/content/gaitpdb/1.0.0/
+- PhysioNet gaitndd: https://physionet.org/content/gaitndd/1.0.0/
+- PhysioNet gaitdb: https://physionet.org/content/gaitdb/1.0.0/
+- WearGait‑PD overview: https://cdrh-rst.fda.gov/weargait-pd
+- WearGait‑PD Synapse: https://www.synapse.org/#!Synapse:syn52540892
+- Figshare PD kinetics/kinematics dataset: https://figshare.com/articles/dataset/A_dataset_of_overground_full-body_kinematics_and_kinetics_in_Parkinson_s_disease/14896881
+- Associated publication (open access): https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9978741/
+
+---
+
+## Command Results
+
+No commands were executed as part of generating this transcript. If you would like, I can run the download and characterization scripts and append the console output and artifact paths here (with timestamps and exit codes).


### PR DESCRIPTION
This pull request introduces two gait datasets relevant for Parkinson's disease research: "Gait in Parkinson’s Disease" (gaitpdb) and "Gait in Neurodegenerative Disease" (gaitndd). 

The datasets are sourced from PhysioNet and provide detailed footfall data necessary for analyzing gait patterns.

### Changes made:
- **datasets/.gitignore**: Added to ignore downloaded dataset content and prevent committing large binaries.
- **datasets/README.md**: Created to provide information about the datasets, how to download them, and licensing details. Both datasets allow academic use under the Open Data Commons Attribution (ODC-By 1.0) License.
- **scripts/download_gait_datasets.R**: Added a script to automate the downloading and extraction of the two datasets. The script checks for existing downloads and provides functionality to force re-download if needed.

### Dataset details:
1. **Gait in Parkinson’s Disease (gaitpdb)**
   - Cohort: 93 patients, 73 controls
   - Data: Vertical ground reaction force records
   - License: ODC-By 1.0
   - [More info](https://physionet.org/content/gaitpdb/1.0.0/)

2. **Gait in Neurodegenerative Disease (gaitndd)**
   - Cohort: Various neurodegenerative diseases
   - Data: Footswitch signals and derived time series
   - License: ODC-By 1.0
   - [More info](https://physionet.org/content/gaitndd/1.0.0/)

This addition facilitates research into gait analysis for Parkinson's disease and aligns with our project goals.

---

> This pull request was co-created with Cosine Genie

Original Task: [CosineRTutorial/4lx4eoi1yb6u](https://cosine.sh/v1x4hernr5ne/CosineRTutorial/task/4lx4eoi1yb6u)
Author: Cris Flagg
