### PR TITLE
Add Note on Creating Transcripts to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,3 +119,11 @@ GitHub Actions workflow (.github/workflows/R-CMD-check.yaml) runs R CMD check on
   - run_app(): launches the bundled Shiny app
 - .Rprofile auto-activates renv when present.
 - Edit DESCRIPTION to update package metadata (name, author, URLs) as needed.
+
+## Note on Creating Transcripts
+
+Transcripts in this repository are generated with an additional instruction added to the Cosine system prompt:
+
+"When you are instructed to create a transcript the purpose is to show the exact interactions that occurred during a session.  This will allow students to read the transcript and understand how to interact with Cosine.  The transcript should be a complete as possible, showing the user input and as close to the Cosine internal step-by-step process and end result as possible."
+
+A transcript of this discussion has been created and linked here: [Creating Transcripts – full transcript](transcripts/creating-transcripts.md)

--- a/transcripts/creating-transcripts.md
+++ b/transcripts/creating-transcripts.md
@@ -1,0 +1,72 @@
+# Conversation Transcript: Note on Creating Transcripts (README update)
+
+Generated: 2025-09-23
+Participants: User and Genie (Cosine AI)
+
+Note on reasoning privacy:
+- This transcript reproduces the user–assistant exchange and a concise, high-level summary of the assistant’s actions.
+- It omits hidden chain-of-thought or internal deliberations. Where helpful, a brief worklog summarizes decisions and steps.
+
+---
+
+## Conversation Log
+
+### 1) User
+Verbatim request:
+
+```
+# TASK
+
+# COMMENT
+
+At the bottom of the readme page include a note on creating transcripts.  Note that the quoted text is added to the Cosine system prompt. Transcripts are generated with the additional instructions provided in the system prompt: "When you are instructed to create a transcript the purpose is to show the exact interactions that occurred during a session.  This will allow students to read the transcript and understand how to interact with Cosine.  The transcript should be a complete as possible, showing the user input and as close to the Cosine internal step-by-step process and end result as possible."  This prompt should be shown in quotes.   Then create a transcript of this discussion and link to it at the end of the paragraph.
+
+# FILESYSTEM
+
+ .Rprofile
+ DESCRIPTION
+ LICENSE
+ R/
+ datasets/
+ github-for-r.md
+ inst/
+ readme.md
+ scripts/
+ tests/
+ transcripts/
+```
+
+### 2) Assistant
+Understood. I will:
+- Append a “Note on Creating Transcripts” section at the bottom of readme.md, including the quoted system prompt instruction verbatim and an inline link to the new transcript.
+- Create transcripts/creating-transcripts.md capturing this exchange in the established transcript format used in this repository.
+
+---
+
+## Assistant Worklog (Concise)
+
+- Reviewed repository structure and existing transcript conventions under transcripts/.
+- Read readme.md and identified the appropriate location for the new note (end of file).
+- Updated readme.md by appending a “Note on Creating Transcripts” section, including the quoted instruction and an inline link to the transcript.
+- Authored transcripts/creating-transcripts.md to document this discussion.
+- Verified internal links are relative (transcripts/creating-transcripts.md) and consistent with other README tutorial links.
+
+---
+
+## Files Added or Updated
+
+- readme.md — appended “Note on Creating Transcripts” section with quoted instruction and link.
+- transcripts/creating-transcripts.md — this transcript.
+
+---
+
+## Links
+
+- README: readme.md (bottom section “Note on Creating Transcripts”)
+- Transcript file: transcripts/creating-transcripts.md
+
+---
+
+## Command Results
+
+No external commands were executed. Changes were applied directly to the repository files.


### PR DESCRIPTION
This pull request adds a new section at the bottom of the README file addressing the creation of transcripts. It includes the verbatim instruction required for transcript generation, ensuring that users understand the intended purpose and format. The quoted text states:

"When you are instructed to create a transcript the purpose is to show the exact interactions that occurred during a session. This will allow students to read the transcript and understand how to interact with Cosine. The transcript should be a complete as possible, showing the user input and as close to the Cosine internal step-by-step process and end result as possible."

Additionally, a transcript of this discussion has been created and linked for reference at the end of the new section.

---

> This pull request was co-created with Cosine Genie

Original Task: [CosineRTutorial/i1b77tforjft](https://cosine.sh/v1x4hernr5ne/CosineRTutorial/task/i1b77tforjft)
Author: Cris Flagg
