### PR TITLE
Add AGENTS.md guidance for repository contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS.md
+
+This file gives coding agents a safe, reliable workflow for contributing to this repository.
+
+## 1) Project purpose and scope
+
+This repository contains:
+- An R package (`cosineR`) with small exported utilities.
+- Data scripts for downloading and characterizing external gait datasets.
+- A bundled Shiny app for interactive dataset exploration.
+- Documentation/transcripts for student-facing tutorials.
+
+Primary goals for agent changes:
+- Keep setup and run commands reproducible.
+- Avoid committing large/generated data.
+- Preserve beginner-friendly workflow in docs.
+
+---
+
+## 2) Repository map (quick orientation)
+
+- `R/` - package functions (e.g., `mean_sd()`, `run_app()`).
+- `inst/app/` - Shiny app (`inst/app/app.R`).
+- `scripts/` - environment setup, analysis, dataset download, dataset characterization.
+- `tests/testthat/` - unit tests.
+- `datasets/` - local downloaded data (ignored by git except README/.gitignore).
+- `outputs/` - generated analysis/characterization artifacts (ignored by git).
+- `.github/workflows/R-CMD-check.yaml` - CI check workflow.
+
+---
+
+## 3) Required setup sequence
+
+From repo root, run:
+
+1. Initialize dependencies
+   - `Rscript scripts/setup_renv.R`
+2. Download datasets (only if working on dataset or app tasks)
+   - `Rscript scripts/download_gait_datasets.R`
+   - Use `--force` only when intentionally re-downloading:
+     - `Rscript scripts/download_gait_datasets.R --force`
+3. Generate characterization outputs needed by app/docs
+   - `Rscript scripts/characterize_gaitpdb.R`
+   - `Rscript scripts/characterize_gaitndd.R`
+
+Notes:
+- Dataset downloads can be large and may take several minutes.
+- Do not assume datasets/outputs exist in a fresh checkout.
+
+---
+
+## 4) Preflight checks before coding
+
+Confirm these expected files exist when your task depends on them:
+
+- `outputs/gaitpdb/characterization_trials.csv`
+- `outputs/gaitndd/characterization_records.csv`
+
+If missing, generate them using the characterization scripts before running app-related checks.
+
+For Shiny work, launch with one of:
+- `R -e "shiny::runApp('inst/app')"`
+- `R -e "devtools::load_all(); cosineR::run_app()"`
+
+---
+
+## 5) Validation checklist before committing
+
+Run the minimum applicable checks for your change:
+
+- Package tests:
+  - `R -e "devtools::test()"`
+- Example analysis:
+  - `Rscript scripts/analysis.R`
+- If app or data logic changed:
+  - Re-run characterization scripts as needed
+  - Smoke test app launch
+
+CI alignment:
+- CI runs roxygen and `rcmdcheck`; keep code compatible with `.github/workflows/R-CMD-check.yaml`.
+
+---
+
+## 6) Data and git safety guardrails
+
+Always:
+- Keep downloaded dataset contents out of git.
+- Keep generated `outputs/` artifacts out of git.
+- Commit only source code/docs/tests/config changes relevant to the task.
+
+Never:
+- Commit `datasets/gaitpdb/*` or `datasets/gaitndd/*` payloads.
+- Commit `outputs/*` generated files.
+- Remove user-authored files or rewrite history unless explicitly requested.
+
+---
+
+## 7) Known pitfalls and conventions
+
+- Several scripts use `library(tidyverse)`. Ensure required packages are available in your environment.
+- The Shiny app expects characterization CSVs in `outputs/`; missing files produce empty views.
+- Preserve beginner-friendly README commands and wording when updating docs.
+- Prefer small, focused commits with clear messages.
+
+---
+
+## 8) Definition of done
+
+A task is done when:
+
+1. The requested change is implemented.
+2. Relevant checks pass locally.
+3. No ignored/generated dataset/output artifacts are staged.
+4. Docs remain accurate for a clean checkout workflow.
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Minimal R Package Scaffold with Shiny App and Analysis Script
 Version: 0.1.0
 Authors@R: c(
     person(given = "Cosine", family = "User", role = c("aut", "cre"), email = "user@example.com")
-)
+    )
 Description: A minimal R package scaffold that includes a simple utility function, a bundled Shiny app, a sample analysis script, unit tests, and CI.
 License: MIT + file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new root `AGENTS.md` tailored to this repository's R package + scripts + Shiny workflow
- document required setup order, including when dataset download/characterization is needed
- add preflight checks for expected output artifacts used by the app
- provide a concise validation checklist aligned with CI behavior
- include git/data guardrails to avoid committing generated outputs and downloaded datasets
- capture known pitfalls and a clear definition of done for agent tasks
- fix malformed `DESCRIPTION` formatting (`Authors@R`) that caused CI dependency resolution to fail

## Why
This repository is used for beginner-friendly R workflows and includes external datasets plus generated artifacts. A dedicated agents guide reduces onboarding friction and helps prevent common mistakes (missing prerequisite outputs, accidental data commits, and incomplete validation).

The additional `DESCRIPTION` fix restores valid package metadata parsing in CI.

## Testing
- documentation and metadata changes only
- CI re-run required to confirm `R-CMD-check` recovery in GitHub Actions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07882c2c-907e-42cd-9404-15519d030b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07882c2c-907e-42cd-9404-15519d030b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

